### PR TITLE
added support to display fingerings as annotations

### DIFF
--- a/src/parsing/musicxml/annotation.ts
+++ b/src/parsing/musicxml/annotation.ts
@@ -21,6 +21,15 @@ export class Annotation {
     return new Annotation(config, log, machine.getText(), 'center', 'bottom');
   }
 
+  static fromFingering(config: Config, log: Logger, musicXML: { fingering: musicxml.Fingering }): Annotation | undefined {
+    const number = musicXML.fingering.getNumber();
+    if (number === null || number === undefined) {
+      return undefined
+    }
+
+    return new Annotation(config, log, `${number}`, 'center', 'top')
+  }
+
   parse(): data.Annotation {
     return {
       type: 'annotation',

--- a/src/parsing/musicxml/note.ts
+++ b/src/parsing/musicxml/note.ts
@@ -73,7 +73,18 @@ export class Note {
     }
 
     const stem = conversions.fromStemToStemDirection(musicXML.note.getStem());
-    const annotations = musicXML.note.getLyrics().map((lyric) => Annotation.fromLyric(config, log, { lyric }));
+    const lyricAnnotations = musicXML.note.getLyrics().map((lyric) => Annotation.fromLyric(config, log, { lyric }));
+    const fingeringAnnotations = musicXML.note
+      .getNotations()
+      .flatMap(n => n.getTechnicals())
+      .flatMap(t => t.getFingerings())
+      .map(fingering => Annotation.fromFingering(config, log, { fingering }))
+      .filter(a => a !== undefined)
+
+    const annotations = [
+      ...lyricAnnotations,
+      ...fingeringAnnotations
+    ];
 
     const code =
       conversions.fromAccidentalTypeToAccidentalCode(musicXML.note.getAccidentalType()) ??


### PR DESCRIPTION
Added support to show fingerings as top annotations. 

<img width="278" height="105" alt="image" src="https://github.com/user-attachments/assets/0409bb21-af4c-40eb-8deb-13b3dc61a204" />


Ideally annotations would have a type so the renderer in vexflow could introduce a config SHOW_FINGERING to only display the finger numbers, when configured.

But as this is my first contribution to the project and I didn't find a `CONTRIBUTION.md` so that's my best guess. 